### PR TITLE
reorg SDKs + Node.js release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ We help developers be successful by nurturing a healthy and welcoming community 
 - [Ownership](devrel/ownership.md)
 - [Resources](resources/README.md)
 - [Scripts](scripts/scripts.md)
-- [SDKs](SDKs/SDKs.md)
+- [SDKs](SDKs/README.md)
 - [Talks](content/talks.md)
 - [Writing Blog Posts](content/writing/blog-posts.md)

--- a/SDKs/Node.js.md
+++ b/SDKs/Node.js.md
@@ -1,0 +1,28 @@
+## Node.js SDK New Release Process
+
+### GitHub
+
+We follow the [semantic versioning standard](https://semver.org).
+
+1. Update the version number in `package.json`
+2. Update `CHANGELOG.md` by adding details about the new version
+3. Commit those changes with the message `chg: 🔖 prepare vX.X.X`
+
+#### Draft a new release
+
+You can do this with the [GitHub CLI](https://github.com/cli/cli):
+
+`gh release create v1.X.X -F CHANGELOG.md`
+
+or manually within the GitHub interface:
+
+1. Create a new tag with the new version number `vX.X.X`
+2. Set the release title to the same name
+3. Copy your release notes `CHANGELOG.md`
+4. Publish the release
+
+Next step is to deploy the package on npm.
+
+### npm
+
+From the command line inside of the Node.js repository folder, run `npm publish`. Note that you need to be a maintainer and connect your user with the npm CLI.

--- a/SDKs/Python.md
+++ b/SDKs/Python.md
@@ -1,5 +1,3 @@
-# SDKs
-
 ## Python SDK New Release Process
 
 ### GitHub

--- a/SDKs/README.md
+++ b/SDKs/README.md
@@ -15,5 +15,5 @@ We also have Computer Vision SDKs, but they aren't maintained by the devrel team
 
 We have additional informations for the SDKs like a new version deployment process
 
-- [Python](python.md)
-- [Node.js](node.js.md)
+- [Python](Python.md)
+- [Node.js](Node.js.md)

--- a/SDKs/README.md
+++ b/SDKs/README.md
@@ -1,0 +1,19 @@
+# SDKs
+
+# Mindee SDKs
+
+We have SDKs for Mindee API for
+- [Python](https://github.com/mindee/mindee-api-python)
+- [Node.js](https://github.com/mindee/mindee-api-nodejs)
+
+We also have Computer Vision SDKs, but they aren't maintained by the devrel team:
+- [JavaScript](https://github.com/mindee/mindee-js)
+- [React](https://github.com/mindee/react-mindee-js)
+- [Vue.js](https://github.com/mindee/vue-mindee-js)
+
+# Additional Informations
+
+We have additional informations for the SDKs like a new version deployment process
+
+- [Python](python.md)
+- [Node.js](node.js.md)


### PR DESCRIPTION
- reorganize the SDKs information
- add instructions on deploying a new Node.js SDK version
